### PR TITLE
Remove stop bar sensors from Approach delay and Arrival on Red reports

### DIFF
--- a/MOE.Common/Migrations/Configuration.cs
+++ b/MOE.Common/Migrations/Configuration.cs
@@ -342,8 +342,6 @@ While each agency should consult with their IT department for specific guideline
                     case 4:
                         detectionType.MetricTypes.Add(context.MetricTypes.Find(5));
                         detectionType.MetricTypes.Add(context.MetricTypes.Find(7));
-                        detectionType.MetricTypes.Add(context.MetricTypes.Find(8));
-                        detectionType.MetricTypes.Add(context.MetricTypes.Find(9));
                         break;
                     case 5:
                         detectionType.MetricTypes.Add(context.MetricTypes.Find(11));


### PR DESCRIPTION
Changes default report configuration to not use lane by lane sensors in AoR and Approach Delay reports.