### PR TITLE
SQL Command Timout

### DIFF
--- a/MOE.Common/Business/WatchDog/WatchDogScan.cs
+++ b/MOE.Common/Business/WatchDog/WatchDogScan.cs
@@ -123,12 +123,12 @@ namespace MOE.Common.Business.WatchDog
 
             if (controllerEventLogRepository.GetRecordCount(signal.SignalID, dateToCheck.AddDays(-1), dateToCheck) > Settings.MinimumRecords)
             {
-                Console.WriteLine("Signal " + signal.SignalID + "Has Current records");
+                Console.WriteLine("Signal " + signal.SignalID + " Has Current records");
                 signalsWithRecords.Add(signal);
             }
             else
             {
-                Console.WriteLine("Signal " + signal.SignalID + "Does Not Have Current records");
+                Console.WriteLine("Signal " + signal.SignalID + " Does Not Have Current records");
                 signalsNoRecords.Add(signal);
                 MOE.Common.Models.SPMWatchDogErrorEvent error = new MOE.Common.Models.SPMWatchDogErrorEvent();
                 error.SignalID = signal.SignalID;
@@ -136,7 +136,7 @@ namespace MOE.Common.Business.WatchDog
                 error.Phase = 0;
                 error.Direction = "";
                 error.TimeStamp = ScanDate;
-                error.Message = "Missing Records";
+                error.Message = "Missing Records - IP: " + signal.IPAddress;
                 error.ErrorCode = 1;
                 MissingRecords.Add(error);
             }
@@ -300,7 +300,7 @@ namespace MOE.Common.Business.WatchDog
                         error.Phase = detector.Approach.ProtectedPhaseNumber;
                         error.TimeStamp = ScanDate;
                         error.Direction = detector.Approach.DirectionType.Description;
-                        error.Message = "Count: "+ currentVolume.ToString();
+                        error.Message = "CH: " + channel.ToString() + " - Count: " + currentVolume.ToString();
                         error.ErrorCode = 2;
                         if (!LowHitCountErrors.Contains(error))
                         {

--- a/MOE.Common/Models/SPM.cs
+++ b/MOE.Common/Models/SPM.cs
@@ -16,6 +16,7 @@ namespace MOE.Common.Models
             : base("name=SPM")
         {
             Database.SetInitializer<SPM>(new CreateDatabaseIfNotExists<SPM>());
+            Database.CommandTimeout = 900;
         }
 
         public static MOE.Common.Models.SPM Create()


### PR DESCRIPTION
Added Command Timeout to prevent slow SQL servers that can not produce results in the default 30 seconds. This will prevent a timeout error that the current code cannot handle and leads to multiple exceptions. TODO: add to config file

Issue #31 